### PR TITLE
DENG-465 extract date configuration to config files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,3 @@ COPY . .
 RUN python -m pip install --no-cache-dir .
 
 ENTRYPOINT ["overwatch"]
-CMD ["run-analysis", "./config_files"]

--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,14 @@ image:
 dev_push:
 	docker tag ${IMAGE_NAME} ${IMAGE_REPO}/${IMAGE_NAME}
 	docker push ${IMAGE_REPO}/${IMAGE_NAME}
- 
+
 run:
 	docker run -v ${CREDENTIAL_VOLUME_MOUNT}:/app/credentials \
 		-e GOOGLE_APPLICATION_CREDENTIALS=/app/credentials/${DESTINATION_CREDENTIAL_FILENAME} \
 		-e SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN} \
 		--name ${CONTAINER_NAME} \
 		--rm \
-		 ${IMAGE_NAME} 
+		 ${IMAGE_NAME} run-analysis ./config_files --date=$(RUN_DATE)
 
 shell:
 	docker run -it --entrypoint=/bin/bash --rm --name ${CONTAINER_NAME} ${IMAGE_NAME}
@@ -45,5 +45,3 @@ test-image: ## Builds test Docker image containing all dev requirements
 
 ci_test: test-image ## Builds test Docker image and executes Python tests
 	docker run ${TEST_IMAGE_NAME} python -m pytest tests analysis
-
-

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ make build
 ## Running Overwatch as a Docker container locally
 After building the docker image use the following command to launch the container:
 ```
-make run CREDENTIAL_VOLUME_MOUNT=<location of service account file> DESTINATION_CREDENTIAL_FILENAME=<service_account_filename>.json SLACK_BOT_TOKEN=<slackbot_token>
+make run RUN_DATE=<YYYY-MM-DD> CREDENTIAL_VOLUME_MOUNT=<location of service account file> DESTINATION_CREDENTIAL_FILENAME=<service_account_filename>.json SLACK_BOT_TOKEN=<slackbot_token>
 ```
 
 To run the docker image with access to a shell prompt use (generally for debugging purposes):

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ python -m pip install -e ".[testing]"
 pre-commit install
 ```
 
+## Developing in PyCharm
+###Run/Debug Configurations
+1. Select `Module name:` from the drop list for the first field and enter `analysis.cli`
+1. In the `Parameters:` field enter `run-analysis --date=2022-11-15 ./config_files`  (any date can be specified)
+1. In the `Environment variables:` field enter
+
+       PYTHONUNBUFFERED=1;SLACK_BOT_TOKEN=<slackbot_token>;GOOGLE_APPLICATION_CREDENTIALS=<service account file>
+    Contact gleonard@mozilla.com for SLACK_BOT_TOKEN
 ## To update dependencies:
 ### DO NOT UPDATE requirements.txt or requirements.in manually!!!
 

--- a/analysis/cli.py
+++ b/analysis/cli.py
@@ -2,6 +2,7 @@ from typing import Iterable
 from datetime import datetime
 
 import click
+import pytz
 
 from analysis.detection.explorer.multiple_dimensions import MultiDimensionEvaluator
 from analysis.detection.explorer.one_dimension import OneDimensionEvaluator
@@ -11,6 +12,8 @@ from analysis.logging import logger
 from analysis.notification.slack import SlackNotifier
 from analysis.reports.generator import ReportGenerator
 from analysis.configuration.loader import Loader
+from analysis.configuration.processing_dates import calculate_date_ranges, ProcessingDateRange
+from analysis.errors import NoDataFoundForDateRange, BigQueryPermissionsError
 
 
 @click.group()
@@ -18,9 +21,17 @@ def cli():
     pass
 
 
-def find_significant_dimensions(profile: AnalysisProfile, date_ranges: dict) -> dict:
+def find_significant_dimensions(
+    profile: AnalysisProfile,
+    previous_date_range: ProcessingDateRange,
+    current_date_range: ProcessingDateRange,
+) -> dict:
     # 1.  Find overall percent change
-    top_level_evaluator = TopLevelEvaluator(profile=profile, date_ranges=date_ranges)
+    top_level_evaluator = TopLevelEvaluator(
+        profile=profile,
+        previous_date_range=previous_date_range,
+        current_date_range=current_date_range,
+    )
     top_level_evaluation = top_level_evaluator.evaluate()
     logger.info(f"top_level_evaluation: {top_level_evaluation}")
 
@@ -29,17 +40,29 @@ def find_significant_dimensions(profile: AnalysisProfile, date_ranges: dict) -> 
     # - contribution to overall change for each value of single dimension.
     # - change to contribution of overall value for each value of single dimension.
 
-    one_dim_evaluator = OneDimensionEvaluator(profile=profile, date_ranges=date_ranges)
+    one_dim_evaluator = OneDimensionEvaluator(
+        profile=profile,
+        previous_date_range=previous_date_range,
+        current_date_range=current_date_range,
+    )
     one_dim_evaluation = one_dim_evaluator.evaluate()
 
-    multi_dim_evaluator = MultiDimensionEvaluator(profile=profile, date_ranges=date_ranges)
+    multi_dim_evaluator = MultiDimensionEvaluator(
+        profile=profile,
+        previous_date_range=previous_date_range,
+        current_date_range=current_date_range,
+    )
     multi_dim_evaluation = multi_dim_evaluator.evaluate()
 
     return top_level_evaluation | one_dim_evaluation | multi_dim_evaluation
 
 
 def issue_report(
-    profile: AnalysisProfile, notif_config: Notification, evaluation: dict, date_ranges: dict
+    profile: AnalysisProfile,
+    notif_config: Notification,
+    evaluation: dict,
+    previous_date_range: ProcessingDateRange,
+    current_date_range: ProcessingDateRange,
 ):
     evaluation["profile"] = profile
 
@@ -47,111 +70,65 @@ def issue_report(
         output_dir="generated_reports",
         template=notif_config.report.template,
         evaluation=evaluation,
-        date_ranges=date_ranges,
+        previous_date_range=previous_date_range,
+        recent_date_range=current_date_range,
     )
 
     pdfreport_filename = report_generator.build_pdf_report()
-    # TODO GLE hard coded to only publish to Slack for MVP
+    # Only publish to Slack for MVP
     notifier = SlackNotifier(output_pdf=pdfreport_filename, config=notif_config.slack)
     notifier.publish_pdf_report()
 
 
-# This function is temporary until the date range config is added.
-def _collect_time_ranges() -> dict[str, dict]:
-    all_dates = {}
-    new_profiles_fenix_date_ranges_of_interest = {
-        "previous_period": {
-            "start_date": datetime.strptime("2022-04-04", "%Y-%m-%d"),
-            "end_date": datetime.strptime("2022-04-10", "%Y-%m-%d"),
-        },
-        "recent_period": {
-            "start_date": datetime.strptime("2022-04-10", "%Y-%m-%d"),
-            "end_date": datetime.strptime("2022-04-16", "%Y-%m-%d"),
-        },
-    }
-    all_dates["Fenix new profiles"] = new_profiles_fenix_date_ranges_of_interest
+class ClickDate(click.ParamType):
+    """Converter for click date string parameters to datetime."""
 
-    new_profiles_desktop_date_ranges_of_interest = {
-        "previous_period": {
-            "start_date": datetime.strptime("2022-05-01", "%Y-%m-%d"),
-            "end_date": datetime.strptime("2022-05-01", "%Y-%m-%d"),
-        },
-        "recent_period": {
-            "start_date": datetime.strptime("2022-06-30", "%Y-%m-%d"),
-            "end_date": datetime.strptime("2022-06-30", "%Y-%m-%d"),
-        },
-    }
-    all_dates["Desktop new profiles"] = new_profiles_desktop_date_ranges_of_interest
+    name = "date"
 
-    dau_fenix_date_ranges_of_interest = {
-        # 7 day configuration, dates are inclusive.  Current max window average is 7 days.
-        # For single day configuration set start_date = end_date.
-        "previous_period": {
-            "start_date": datetime.strptime("2022-03-18", "%Y-%m-%d"),
-            "end_date": datetime.strptime("2022-03-18", "%Y-%m-%d"),
-        },
-        "recent_period": {
-            "start_date": datetime.strptime("2022-03-25", "%Y-%m-%d"),
-            "end_date": datetime.strptime("2022-03-25", "%Y-%m-%d"),
-        },
-    }
-    all_dates["Fenix DAU"] = dau_fenix_date_ranges_of_interest
-
-    mau_firefox_desktop_date_ranges_of_interest = {
-        # 7 day configuration, dates are inclusive.  Current max window average is 7 days.
-        # For single day configuration set start_date = end_date.
-        "previous_period": {
-            "start_date": datetime.strptime("2021-11-02", "%Y-%m-%d"),
-            "end_date": datetime.strptime("2021-11-02", "%Y-%m-%d"),
-        },
-        "recent_period": {
-            "start_date": datetime.strptime("2021-11-30", "%Y-%m-%d"),
-            "end_date": datetime.strptime("2021-11-30", "%Y-%m-%d"),
-        },
-    }
-    all_dates["Desktop MAU"] = mau_firefox_desktop_date_ranges_of_interest
-
-    download_date_ranges_of_interest = {
-        # 7 day configuration, dates are inclusive.  Current max window average is 7 days.
-        # For single day configuration set start_date = end_date.
-        "previous_period": {
-            "start_date": datetime.strptime("2022-07-30", "%Y-%m-%d"),
-            "end_date": datetime.strptime("2022-07-30", "%Y-%m-%d"),
-        },
-        "recent_period": {
-            "start_date": datetime.strptime("2022-08-06", "%Y-%m-%d"),
-            "end_date": datetime.strptime("2022-08-06", "%Y-%m-%d"),
-        },
-    }
-
-    all_dates["Site Metrics Downloads"] = download_date_ranges_of_interest
-    return all_dates
+    def convert(self, value, param, ctx):
+        """Convert a string to datetime."""
+        if isinstance(value, datetime):
+            return value
+        return datetime.strptime(value, "%Y-%m-%d").replace(tzinfo=pytz.utc)
 
 
 @cli.command()
 @click.argument("paths", required=True, type=click.Path(exists=True, file_okay=True), nargs=-1)
-def run_analysis(paths: Iterable[str]):
-    logger.info("Starting analysis")
-    date_ranges = _collect_time_ranges()
+@click.option(
+    "--date",
+    type=ClickDate(),
+    help="Date for which projects should be analyzed",
+    metavar="YYYY-MM-DD",
+    required=True,
+)
+def run_analysis(paths: Iterable[str], date: ClickDate):
+    logger.info(f"Starting analysis for date: {date} (excluded)")
     for path in paths:
         configs = Loader.load_all_config_files(path)
 
-        # TODO GLE temp mapping of date range to Config
-        #  will be removed once data range config completed.
-        run_config = []
         for config in configs:
-            run_config.append((config, date_ranges[config.analysis_profile.name]))
-
-        for (config, date_ranges) in run_config:
-            significant_dims = find_significant_dimensions(
-                profile=config.analysis_profile, date_ranges=date_ranges
+            previous_date_range, current_date_range = calculate_date_ranges(
+                dataset_config=config.analysis_profile.dataset, exclusive_end_date=date
             )
-            issue_report(
-                profile=config.analysis_profile,
-                evaluation=significant_dims,
-                date_ranges=date_ranges,
-                notif_config=config.notification,
-            )
+            try:
+                significant_dims = find_significant_dimensions(
+                    profile=config.analysis_profile,
+                    previous_date_range=previous_date_range,
+                    current_date_range=current_date_range,
+                )
+                issue_report(
+                    profile=config.analysis_profile,
+                    evaluation=significant_dims,
+                    previous_date_range=previous_date_range,
+                    current_date_range=current_date_range,
+                    notif_config=config.notification,
+                )
+            except NoDataFoundForDateRange as e:
+                # TODO GLE Need to notify of error
+                logger.error(e)
+            except BigQueryPermissionsError as e:
+                # TODO GLE Need to notify of error
+                logger.error(e)
     logger.info("Analysis completed")
 
 

--- a/analysis/configuration/configs.py
+++ b/analysis/configuration/configs.py
@@ -12,13 +12,16 @@ class PercentChange:
 class Dataset:
     metric_name: str = attr.ib()
     table_name: str = attr.ib()
+    date_range_offset: int = attr.ib()
+    current_date_range: int = attr.ib()
+    previous_date_range: int = attr.ib()
     app_name: str = attr.ib(None)
 
 
 @attr.s(auto_attribs=True)
 class AnalysisProfile:
     name: str = attr.ib()
-    # TODO GLE in the future there may be other calculations types supported.
+    # In the future there may be other calculations types supported.
     percent_change: PercentChange = attr.ib()
     dataset: Dataset = attr.ib()
 
@@ -34,7 +37,7 @@ class Report:
     template: str = attr.ib()
 
 
-# TODO GLE Notification will need to support multiple notification types (e.g. slack, jira).
+# In the future Notification will need to support multiple notification types (e.g. slack, jira).
 @attr.s(auto_attribs=True)
 class Notification:
     report: Report = attr.ib()

--- a/analysis/configuration/processing_dates.py
+++ b/analysis/configuration/processing_dates.py
@@ -32,10 +32,10 @@ def calculate_date_ranges(
     """
     previous_date_range = dataset_config.previous_date_range
     current_date_range = dataset_config.current_date_range
-    # the number of days between the end of the previous date range and the start of the current
-    # date range, may be negative if they overlap
     date_range_offset = dataset_config.date_range_offset
 
+    # the number of days between the end of the previous date range and the start of the current
+    # date range, may be negative if they overlap
     dataset_gap = date_range_offset - previous_date_range
 
     previous_start_date = exclusive_end_date - timedelta(

--- a/analysis/configuration/processing_dates.py
+++ b/analysis/configuration/processing_dates.py
@@ -1,0 +1,54 @@
+import attr
+
+from datetime import datetime, timedelta
+
+from analysis.configuration.configs import Dataset
+
+
+@attr.s(auto_attribs=True)
+class ProcessingDateRange:
+    start_date: datetime = attr.ib()
+    end_date: datetime = attr.ib()
+
+
+def calculate_date_ranges(
+    dataset_config: Dataset, exclusive_end_date: datetime
+) -> (ProcessingDateRange, ProcessingDateRange):
+    """
+    Determine the start and end dates of the previous and current dataset ranges exclusive of the
+    provided date.
+    previous_start_date = date - (current_date_range + dataset_gap + previous_date_range)
+    previous_end_date = date - (current_date_range + dataset_gap)
+
+    current_start_date = date - current_date_range
+    current_end_date = date
+
+    date_range_offset is the number of days between the start of the previous date range and the
+    current date range.
+    @param dataset_config: config loaded from the analysis profile configuration files.
+    @param exclusive_end_date: date provided via Airflow.  The calculated date ranges will end on
+    the prior day.
+    @return: a tuple of ProcessingDateRanges (previous, current)
+    """
+    previous_date_range = dataset_config.previous_date_range
+    current_date_range = dataset_config.current_date_range
+    # the number of days between the end of the previous date range and the start of the current
+    # date range, may be negative if they overlap
+    date_range_offset = dataset_config.date_range_offset
+
+    dataset_gap = date_range_offset - previous_date_range
+
+    previous_start_date = exclusive_end_date - timedelta(
+        days=(current_date_range + dataset_gap + previous_date_range)
+    )
+    previous_end_date = exclusive_end_date - timedelta(days=(current_date_range + dataset_gap))
+    previous_date_range = ProcessingDateRange(
+        start_date=previous_start_date, end_date=previous_end_date
+    )
+
+    current_start_date = exclusive_end_date - timedelta(days=current_date_range)
+    current_date_range = ProcessingDateRange(
+        start_date=current_start_date, end_date=exclusive_end_date
+    )
+
+    return previous_date_range, current_date_range

--- a/analysis/detection/explorer/top_level.py
+++ b/analysis/detection/explorer/top_level.py
@@ -3,19 +3,26 @@ from pandas import DataFrame
 
 from analysis.data.metric import MetricLookupManager
 from analysis.configuration.configs import AnalysisProfile
+from analysis.configuration.processing_dates import ProcessingDateRange
 
 
 class TopLevelEvaluator:
-    def __init__(self, profile: AnalysisProfile, date_ranges: dict):
+    def __init__(
+        self,
+        profile: AnalysisProfile,
+        previous_date_range: ProcessingDateRange,
+        current_date_range: ProcessingDateRange,
+    ):
         self.profile = profile
-        self.date_ranges = date_ranges
+        self.previous_date_range = previous_date_range
+        self.recent_date_range = current_date_range
 
     def _get_current_and_baseline_values(self) -> DataFrame:
         current_df = MetricLookupManager().get_metric_with_date_range(
             metric_name=self.profile.dataset.metric_name,
             table_name=self.profile.dataset.table_name,
             app_name=self.profile.dataset.app_name,
-            date_range=self.date_ranges.get("recent_period"),
+            date_range=self.recent_date_range,
         )
         current_df["timeframe"] = "current"
 
@@ -23,7 +30,7 @@ class TopLevelEvaluator:
             metric_name=self.profile.dataset.metric_name,
             table_name=self.profile.dataset.table_name,
             app_name=self.profile.dataset.app_name,
-            date_range=self.date_ranges.get("previous_period"),
+            date_range=self.previous_date_range,
         )
         baseline_df["timeframe"] = "baseline"
 

--- a/analysis/errors.py
+++ b/analysis/errors.py
@@ -1,0 +1,16 @@
+from analysis.configuration.processing_dates import ProcessingDateRange
+
+
+class NoDataFoundForDateRange(Exception):
+    def __init__(self, metric: str, query: str, date_range: ProcessingDateRange):
+        super().__init__(
+            f"No data found for metric: {metric} date_range: {date_range} query: \n{query}"
+        )
+
+
+class BigQueryPermissionsError(Exception):
+    def __init__(self, metric: str, query: str, date_range: ProcessingDateRange, msg: str):
+        super().__init__(
+            f"Unable to access data for metric: {metric} date_range: {date_range} {msg }query: "
+            f"\n{query} "
+        )

--- a/analysis/notification/slack.py
+++ b/analysis/notification/slack.py
@@ -33,7 +33,5 @@ class SlackNotifier:
             )
             assert response["file"]  # the uploaded file
         except SlackApiError as e:
-            # You will get a SlackApiError if "ok" is False
-            logger.error(
-                f'Unable to upload file to Slack channel, received: {e.response["status"]}'
-            )
+            # TODO GLE how to notify if cannot push to Slack?
+            logger.error(f"Unable to upload file to Slack channel, received: {e.response}")

--- a/analysis/reports/generator.py
+++ b/analysis/reports/generator.py
@@ -4,11 +4,19 @@ from pathlib import Path
 
 import pdfkit
 from jinja2 import Environment, FileSystemLoader
+from analysis.configuration.processing_dates import ProcessingDateRange
 
 
 # TODO GLE A lot more thought needs to be added to the report/notfication.
 class ReportGenerator:
-    def __init__(self, output_dir, template: str, evaluation: dict, date_ranges: dict):
+    def __init__(
+        self,
+        output_dir,
+        template: str,
+        evaluation: dict,
+        previous_date_range: ProcessingDateRange,
+        recent_date_range: ProcessingDateRange,
+    ):
         self.template = template
         self.input_path = Path(os.path.dirname(__file__))
         filename_base = (
@@ -19,7 +27,7 @@ class ReportGenerator:
                 else ""
             )
             + "_"
-            + date_ranges.get("recent_period").get("end_date").strftime("%Y-%m-%d")
+            + recent_date_range.end_date.strftime("%Y-%m-%d")
         )
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
@@ -27,7 +35,8 @@ class ReportGenerator:
         self.output_html = os.path.join(output_dir, filename_base + ".html")
         self.output_pdf = os.path.join(output_dir, filename_base + ".pdf")
         self.evaluation = evaluation
-        self.date_ranges = date_ranges
+        self.previous_date_range = previous_date_range
+        self.recent_date_range = recent_date_range
 
     def build_html_report(self):
         self.evaluation["creation_time"] = str(datetime.now())
@@ -39,7 +48,8 @@ class ReportGenerator:
             fh.write(
                 template.render(
                     evaluation=self.evaluation,
-                    date_ranges=self.date_ranges,
+                    previous_date_range=self.previous_date_range,
+                    recent_date_range=self.recent_date_range,
                 )
             )
 

--- a/analysis/reports/templates/report_version2.html.j2
+++ b/analysis/reports/templates/report_version2.html.j2
@@ -10,8 +10,8 @@
 <h1>Automated Analysis</h1>
     <h3>Created: {{evaluation.creation_time}}</h3>
     <p><b>Metric Name:</b> {{evaluation.profile.dataset.metric_name}}</p>
-    <p><b>Previous Period:</b> {{date_ranges.previous_period.start_date}} to {{date_ranges.previous_period.end_date}}</p>
-    <p><b>Recent Period:</b> {{date_ranges.recent_period.start_date}} to {{date_ranges.recent_period.end_date}}</p>
+    <p><b>Previous Period:</b> {{previous_date_range.start_date}} to {{previous_date_range.end_date}} (exclusive)</p>
+    <p><b>Recent Period:</b> {{recent_date_range.start_date}} to {{recent_date_range.end_date}} (exclusive)</p>
 
     <h2>Overall</h2>
     <p><b>Percent change:</b> {{evaluation.top_level_percent_change}}% </p>

--- a/config_files/desktop-mau.toml
+++ b/config_files/desktop-mau.toml
@@ -8,6 +8,10 @@ metric_name="mau"
 # this will have to specify the query template
 table_name="active_user_aggregates"
 app_name="Firefox Desktop"  # this is very specific
+date_range_offset = 28
+current_date_range= 1
+previous_date_range = 1
+
 
 [analysis_profile.percent_change]
 contrib_to_overall_change_threshold_percent = 1

--- a/config_files/desktop-new-profiles.toml
+++ b/config_files/desktop-new-profiles.toml
@@ -8,14 +8,17 @@ metric_name="new_profiles"
 # this will have to specify the query template
 table_name="active_user_aggregates"
 app_name="Firefox Desktop"  # this is very specific
+date_range_offset = 60
+current_date_range= 1
+previous_date_range = 1
 
 [analysis_profile.percent_change]
 contrib_to_overall_change_threshold_percent = 0.25
 dimensions=[
     "region_name",
-#    "subregion_name",
-#    "country",
-#    "app_version",
+    "subregion_name",
+    "country",
+    "app_version",
 ]
 sort_by=[
     "contrib_to_overall_change",

--- a/config_files/fenix-dau.toml
+++ b/config_files/fenix-dau.toml
@@ -9,6 +9,10 @@ metric_name="dau"
 # this will have to specify the query template
 table_name="active_user_aggregates"
 app_name="Fenix"  # this is very specific
+date_range_offset = 7
+current_date_range= 1
+previous_date_range = 1
+
 
 [analysis_profile.percent_change]
 contrib_to_overall_change_threshold_percent = 1

--- a/config_files/fenix-new-profiles.toml
+++ b/config_files/fenix-new-profiles.toml
@@ -10,14 +10,17 @@ metric_name="new_profiles"
 # this will have to specify the query template
 table_name="active_user_aggregates"
 app_name="Fenix"  # this is very specific
+date_range_offset = 6
+current_date_range= 7
+previous_date_range = 7
 
 [analysis_profile.percent_change]
 contrib_to_overall_change_threshold_percent = 1
 dimensions=[
             "region_name",
-#            "subregion_name",
-#            "country",
-#            "channel",
+            "subregion_name",
+            "country",
+            "channel",
 ]
 sort_by=[
     "contrib_to_overall_change",

--- a/config_files/site-metric-downloads.toml
+++ b/config_files/site-metric-downloads.toml
@@ -1,5 +1,3 @@
-# Analysis Example 5
-# Download tracking
 [analysis_profile]
 name="Site Metrics Downloads"
 
@@ -7,6 +5,9 @@ name="Site Metrics Downloads"
 metric_name="downloads"
 # this will have to specify the query template
 table_name="www_site_metrics_summary_v1"
+date_range_offset = 7
+current_date_range= 1
+previous_date_range = 1
 
 [analysis_profile.percent_change]
 contrib_to_overall_change_threshold_percent = 1

--- a/dags/overwatch.py
+++ b/dags/overwatch.py
@@ -22,23 +22,28 @@ default_args = {
     "retry_delay": timedelta(minutes=30),
 }
 
-# temp for finding dag easily.
+# TODO GLE temp for finding dag easily.
 tags = ["overwatch"]
 image = "gcr.io/automated-analysis-dev/overwatch:" + Variable.get("overwatch_image_version")
 
-with DAG("overwatch", default_args=default_args, schedule_interval="@daily", doc_md=__doc__, tags=tags,) as dag:
+with DAG(
+    "overwatch",
+    default_args=default_args,
+    schedule_interval="@daily",
+    doc_md=__doc__,
+    tags=tags,
+) as dag:
     run_analysis = GKEPodOperator(
         task_id="run_analysis",
         name="run_analysis",
         image=image,
         email=["gleonard@mozilla.com"],
         dag=dag,
-        env_vars={
-            "SLACK_BOT_TOKEN": Variable.get("overwatch_slack_token")
-        },
+        env_vars={"SLACK_BOT_TOKEN": Variable.get("overwatch_slack_token")},
+        arguments=["run-analysis", "--date={{ ds }}", "./config_files/"],
         # Temp setting for dev testing.
-        gcp_conn_id='google_cloud_gke_sandbox',
-        project_id='moz-fx-data-gke-sandbox',
-        cluster_name='gleonard-gke-sandbox',
-        location='us-west1',
+        gcp_conn_id="google_cloud_gke_sandbox",
+        project_id="moz-fx-data-gke-sandbox",
+        cluster_name="gleonard-gke-sandbox",
+        location="us-west1",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from analysis.configuration.loader import Loader
+from analysis.configuration.processing_dates import ProcessingDateRange
 
 import pytest
 from pandas import DataFrame, concat
@@ -122,16 +123,16 @@ def multi_dimension_df(mock_current_multi_dimension_values, mock_baseline_multi_
 
 
 @pytest.fixture
-def date_ranges_of_interest():
-    return {
-        # 7 day configuration, dates are inclusive.  Current max window average is 7 days.
-        # For single day configuration set start_date = end_date.
-        "previous_period": {
-            "start_date": datetime.strptime("2022-04-02", "%Y-%m-%d"),
-            "end_date": datetime.strptime("2022-04-02", "%Y-%m-%d"),
-        },
-        "recent_period": {
-            "start_date": datetime.strptime("2022-04-09", "%Y-%m-%d"),
-            "end_date": datetime.strptime("2022-04-09", "%Y-%m-%d"),
-        },
-    }
+def mock_previous_date_range():
+    return ProcessingDateRange(
+        start_date=datetime.strptime("2022-04-02", "%Y-%m-%d"),
+        end_date=datetime.strptime("2022-04-02", "%Y-%m-%d"),
+    )
+
+
+@pytest.fixture
+def mock_current_date_range():
+    return ProcessingDateRange(
+        start_date=datetime.strptime("2022-04-09", "%Y-%m-%d"),
+        end_date=datetime.strptime("2022-04-09", "%Y-%m-%d"),
+    )

--- a/tests/fixtures/config_files/sample-config-all-fields.toml
+++ b/tests/fixtures/config_files/sample-config-all-fields.toml
@@ -7,6 +7,9 @@ name="Config with all fields"
 metric_name="unit_test_metric"
 table_name="test"
 app_name="unit test app_name"
+date_range_offset = 14
+current_date_range= 1
+previous_date_range = 7
 
 [analysis_profile.percent_change]
 contrib_to_overall_change_threshold_percent = 1

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -24,6 +24,9 @@ def test_load_config(mock_config: Config):
     assert mock_config.analysis_profile.dataset.metric_name == "unit_test_metric"
     assert mock_config.analysis_profile.dataset.table_name == "test"
     assert mock_config.analysis_profile.dataset.app_name == "unit test app_name"
+    assert mock_config.analysis_profile.dataset.date_range_offset == 14
+    assert mock_config.analysis_profile.dataset.current_date_range == 1
+    assert mock_config.analysis_profile.dataset.previous_date_range == 7
 
     assert mock_config.notification
     assert mock_config.notification.report

--- a/tests/test_multiple_dimensions.py
+++ b/tests/test_multiple_dimensions.py
@@ -4,7 +4,9 @@ from pandas._testing import assert_frame_equal
 from analysis.detection.explorer.multiple_dimensions import MultiDimensionEvaluator
 
 
-def test_percent_change(date_ranges_of_interest, multi_dimension_df, mock_analysis_profile):
+def test_percent_change(
+    mock_previous_date_range, mock_current_date_range, multi_dimension_df, mock_analysis_profile
+):
     rows = [
         ["mx", "nightly", 100.0, "country", "channel"],
         ["us", "nightly", -80.0, "country", "channel"],
@@ -26,13 +28,19 @@ def test_percent_change(date_ranges_of_interest, multi_dimension_df, mock_analys
     expected_df = DataFrame(rows, columns=cols)
 
     percent_change = MultiDimensionEvaluator(
-        profile=mock_analysis_profile, date_ranges=date_ranges_of_interest
+        profile=mock_analysis_profile,
+        previous_date_range=mock_previous_date_range,
+        current_date_range=mock_current_date_range,
     )._calculate_percent_change(df=multi_dimension_df)
     assert_frame_equal(expected_df, percent_change)
 
 
 def test_calculate_contribution_to_overall_change(
-    date_ranges_of_interest, multi_dimension_df, parent_df, mock_analysis_profile
+    mock_previous_date_range,
+    mock_current_date_range,
+    multi_dimension_df,
+    parent_df,
+    mock_analysis_profile,
 ):
     # calculation =
     # 100 * (current_value - baseline_value) / abs(parent_baseline_value - parent_current_value)
@@ -57,14 +65,20 @@ def test_calculate_contribution_to_overall_change(
     expected_df = DataFrame(rows, columns=cols)
 
     contr_to_change = MultiDimensionEvaluator(
-        profile=mock_analysis_profile, date_ranges=date_ranges_of_interest
+        profile=mock_analysis_profile,
+        previous_date_range=mock_previous_date_range,
+        current_date_range=mock_current_date_range,
     )._calculate_contribution_to_overall_change(current_df=multi_dimension_df, parent_df=parent_df)
 
     assert_frame_equal(expected_df, contr_to_change)
 
 
 def test_change_to_contribution(
-    date_ranges_of_interest, multi_dimension_df, parent_df, mock_analysis_profile
+    mock_previous_date_range,
+    mock_current_date_range,
+    multi_dimension_df,
+    parent_df,
+    mock_analysis_profile,
 ):
     # calculation =
     # 100 * ((current_value/parent_current_value) - (baseline_value/parent_baseline_value))
@@ -91,14 +105,20 @@ def test_change_to_contribution(
     expected_df = DataFrame(rows, columns=cols)
 
     change_to_contrib = MultiDimensionEvaluator(
-        profile=mock_analysis_profile, date_ranges=date_ranges_of_interest
+        profile=mock_analysis_profile,
+        previous_date_range=mock_previous_date_range,
+        current_date_range=mock_current_date_range,
     )._calculate_change_to_contribution(current_df=multi_dimension_df, parent_df=parent_df)
 
     assert_frame_equal(expected_df, change_to_contrib)
 
 
 def test_calculate_significance(
-    date_ranges_of_interest, multi_dimension_df, parent_df, mock_analysis_profile
+    mock_previous_date_range,
+    mock_current_date_range,
+    multi_dimension_df,
+    parent_df,
+    mock_analysis_profile,
 ):
     rows = [
         ["ca", "release", 52.5817, "country", "channel"],
@@ -122,7 +142,9 @@ def test_calculate_significance(
     expected_df = DataFrame(rows, columns=cols)
 
     significance = MultiDimensionEvaluator(
-        profile=mock_analysis_profile, date_ranges=date_ranges_of_interest
+        profile=mock_analysis_profile,
+        previous_date_range=mock_previous_date_range,
+        current_date_range=mock_current_date_range,
     )._calculate_significance(current_df=multi_dimension_df, parent_df=parent_df)
 
     assert_frame_equal(expected_df, significance)

--- a/tests/test_one_dimension.py
+++ b/tests/test_one_dimension.py
@@ -4,7 +4,9 @@ from pandas.testing import assert_frame_equal
 from analysis.detection.explorer.one_dimension import OneDimensionEvaluator
 
 
-def test_percent_change(date_ranges_of_interest, dimension_df, mock_analysis_profile):
+def test_percent_change(
+    mock_previous_date_range, mock_current_date_range, dimension_df, mock_analysis_profile
+):
     rows = [
         ["mx", 26.6667, "country"],
         ["ca", 14.2857, "country"],
@@ -14,13 +16,19 @@ def test_percent_change(date_ranges_of_interest, dimension_df, mock_analysis_pro
     expected_df = DataFrame(rows, columns=cols)
 
     percent_change = OneDimensionEvaluator(
-        profile=mock_analysis_profile, date_ranges=date_ranges_of_interest
+        profile=mock_analysis_profile,
+        previous_date_range=mock_previous_date_range,
+        current_date_range=mock_current_date_range,
     )._calculate_percent_change(df=dimension_df)
     assert_frame_equal(expected_df, percent_change)
 
 
 def test_calculate_contribution_to_overall_change(
-    date_ranges_of_interest, dimension_df, parent_df, mock_analysis_profile
+    mock_previous_date_range,
+    mock_current_date_range,
+    dimension_df,
+    parent_df,
+    mock_analysis_profile,
 ):
     # calculation =
     # 100 * (current_value - baseline_value) / abs((parent_baseline_value - parent_current_value))
@@ -33,14 +41,20 @@ def test_calculate_contribution_to_overall_change(
     expected_df = DataFrame(rows, columns=cols)
 
     contr_to_change = OneDimensionEvaluator(
-        profile=mock_analysis_profile, date_ranges=date_ranges_of_interest
+        profile=mock_analysis_profile,
+        previous_date_range=mock_previous_date_range,
+        current_date_range=mock_current_date_range,
     )._calculate_contribution_to_overall_change(current_df=dimension_df, parent_df=parent_df)
 
     assert_frame_equal(expected_df, contr_to_change)
 
 
 def test_change_to_contribution(
-    date_ranges_of_interest, dimension_df, parent_df, mock_analysis_profile
+    mock_previous_date_range,
+    mock_current_date_range,
+    dimension_df,
+    parent_df,
+    mock_analysis_profile,
 ):
     # calculation =
     # 100 * ((current_value/parent_current_value) - (baseline_value/parent_baseline_value))
@@ -55,14 +69,20 @@ def test_change_to_contribution(
     expected_df = DataFrame(rows, columns=cols)
 
     change_to_contrib = OneDimensionEvaluator(
-        profile=mock_analysis_profile, date_ranges=date_ranges_of_interest
+        profile=mock_analysis_profile,
+        previous_date_range=mock_previous_date_range,
+        current_date_range=mock_current_date_range,
     )._calculate_change_to_contribution(current_df=dimension_df, parent_df=parent_df)
 
     assert_frame_equal(expected_df, change_to_contrib)
 
 
 def test_calculate_significance(
-    date_ranges_of_interest, dimension_df, parent_df, mock_analysis_profile
+    mock_previous_date_range,
+    mock_current_date_range,
+    dimension_df,
+    parent_df,
+    mock_analysis_profile,
 ):
     rows = [
         ["us", 62.7657, "country"],
@@ -73,7 +93,9 @@ def test_calculate_significance(
     expected_df = DataFrame(rows, columns=cols)
 
     significance = OneDimensionEvaluator(
-        profile=mock_analysis_profile, date_ranges=date_ranges_of_interest
+        profile=mock_analysis_profile,
+        previous_date_range=mock_previous_date_range,
+        current_date_range=mock_current_date_range,
     )._calculate_significance(current_df=dimension_df, parent_df=parent_df)
 
     assert_frame_equal(expected_df, significance)

--- a/tests/test_processing_dates.py
+++ b/tests/test_processing_dates.py
@@ -1,0 +1,71 @@
+from datetime import datetime
+import pytz
+from analysis.configuration.processing_dates import calculate_date_ranges
+
+
+def test_calculate_date_ranges(mock_analysis_profile):
+    airflow_date = datetime.strptime("2022-04-17", "%Y-%m-%d").replace(tzinfo=pytz.utc)
+    mock_analysis_profile.dataset.date_range_offset = 7
+    mock_analysis_profile.dataset.previous_date_range = 7
+    mock_analysis_profile.dataset.current_date_range = 7
+
+    previous_date_range, recent_date_range = calculate_date_ranges(
+        mock_analysis_profile.dataset, airflow_date
+    )
+
+    assert previous_date_range.start_date.strftime("%Y-%m-%d") == "2022-04-03"
+    assert previous_date_range.end_date.strftime("%Y-%m-%d") == "2022-04-10"
+
+    assert recent_date_range.start_date.strftime("%Y-%m-%d") == "2022-04-10"
+    assert recent_date_range.end_date.strftime("%Y-%m-%d") == "2022-04-17"
+
+
+def test_calculate_date_ranges_overlapping(mock_analysis_profile):
+    airflow_date = datetime.strptime("2022-04-17", "%Y-%m-%d").replace(tzinfo=pytz.utc)
+    mock_analysis_profile.dataset.date_range_offset = 6
+    mock_analysis_profile.dataset.previous_date_range = 7
+    mock_analysis_profile.dataset.current_date_range = 7
+
+    previous_date_range, recent_date_range = calculate_date_ranges(
+        mock_analysis_profile.dataset, airflow_date
+    )
+
+    assert previous_date_range.start_date.strftime("%Y-%m-%d") == "2022-04-04"
+    assert previous_date_range.end_date.strftime("%Y-%m-%d") == "2022-04-11"
+
+    assert recent_date_range.start_date.strftime("%Y-%m-%d") == "2022-04-10"
+    assert recent_date_range.end_date.strftime("%Y-%m-%d") == "2022-04-17"
+
+
+def test_calculate_date_ranges_with_gap(mock_analysis_profile):
+    airflow_date = datetime.strptime("2022-04-30", "%Y-%m-%d").replace(tzinfo=pytz.utc)
+    mock_analysis_profile.dataset.date_range_offset = 14
+    mock_analysis_profile.dataset.previous_date_range = 7
+    mock_analysis_profile.dataset.current_date_range = 7
+
+    previous_date_range, recent_date_range = calculate_date_ranges(
+        mock_analysis_profile.dataset, airflow_date
+    )
+
+    assert previous_date_range.start_date.strftime("%Y-%m-%d") == "2022-04-09"
+    assert previous_date_range.end_date.strftime("%Y-%m-%d") == "2022-04-16"
+
+    assert recent_date_range.start_date.strftime("%Y-%m-%d") == "2022-04-23"
+    assert recent_date_range.end_date.strftime("%Y-%m-%d") == "2022-04-30"
+
+
+def test_calculate_date_ranges_single_day(mock_analysis_profile):
+    airflow_date = datetime.strptime("2022-04-17", "%Y-%m-%d").replace(tzinfo=pytz.utc)
+    mock_analysis_profile.dataset.date_range_offset = 14
+    mock_analysis_profile.dataset.previous_date_range = 1
+    mock_analysis_profile.dataset.current_date_range = 1
+
+    previous_date_range, recent_date_range = calculate_date_ranges(
+        mock_analysis_profile.dataset, airflow_date
+    )
+
+    assert previous_date_range.start_date.strftime("%Y-%m-%d") == "2022-04-02"
+    assert previous_date_range.end_date.strftime("%Y-%m-%d") == "2022-04-03"
+
+    assert recent_date_range.start_date.strftime("%Y-%m-%d") == "2022-04-16"
+    assert recent_date_range.end_date.strftime("%Y-%m-%d") == "2022-04-17"

--- a/tests/test_top_level.py
+++ b/tests/test_top_level.py
@@ -1,25 +1,23 @@
 from datetime import datetime
 
 from analysis.detection.explorer.top_level import TopLevelEvaluator
+from analysis.configuration.processing_dates import ProcessingDateRange
 
 
 def test_percent_change(parent_df, mock_analysis_profile):
-    date_ranges_of_interest = {
-        # 7 day configuration, dates are inclusive.  Current max window average is 7 days.
-        # For single day configuration set start_date = end_date.
-        "previous_period": {
-            "start_date": datetime.strptime("2022-04-02", "%Y-%m-%d"),
-            "end_date": datetime.strptime("2022-04-02", "%Y-%m-%d"),
-        },
-        "recent_period": {
-            "start_date": datetime.strptime("2022-04-09", "%Y-%m-%d"),
-            "end_date": datetime.strptime("2022-04-09", "%Y-%m-%d"),
-        },
-    }
-
+    previous_date_range = ProcessingDateRange(
+        start_date=datetime.strptime("2022-04-02", "%Y-%m-%d"),
+        end_date=datetime.strptime("2022-04-02", "%Y-%m-%d"),
+    )
+    recent_date_range = ProcessingDateRange(
+        start_date=datetime.strptime("2022-04-09", "%Y-%m-%d"),
+        end_date=datetime.strptime("2022-04-09", "%Y-%m-%d"),
+    )
     expected_percent = round(100 * (124 - 116) / 116, 4)
 
     percent_change = TopLevelEvaluator(
-        profile=mock_analysis_profile, date_ranges=date_ranges_of_interest
+        profile=mock_analysis_profile,
+        previous_date_range=previous_date_range,
+        current_date_range=recent_date_range,
     )._calculate_percent_change(df=parent_df)
     assert percent_change == expected_percent


### PR DESCRIPTION
Added date range configuration to config files.  Continuation of https://github.com/mozilla/overwatch-mvp/pull/4

- Added support for date parameter <YYY-MM-DD> to `cli.py` and `overwatch.py` DAG
- Added date ranges to `config_files`
- Updated current queries to exclude end date [start_date, end_date).  When the Overwatch DAG is executed the date is the current run day however we want to process only up to midnight.
- Updated report template `report_version2.html.j2` to indicate the end date is excluded from the calculations
- Replaced the dict representing the processing date ranges with `ProcessingDateRange`.  This required changes across the `detection/explorer` code, query setup, report template and test files.
- Added error handling to `metrics.py`and `cli.py` for `NoDataFoundForDateRange` and `BigQueryPermissionsError` 