### PR TITLE
DENG-467 convert sql queries to templates

### DIFF
--- a/analysis/cli.py
+++ b/analysis/cli.py
@@ -13,7 +13,7 @@ from analysis.notification.slack import SlackNotifier
 from analysis.reports.generator import ReportGenerator
 from analysis.configuration.loader import Loader
 from analysis.configuration.processing_dates import calculate_date_ranges, ProcessingDateRange
-from analysis.errors import NoDataFoundForDateRange, BigQueryPermissionsError
+from analysis.errors import NoDataFoundForDateRange, BigQueryPermissionsError, SqlNotDefined
 
 
 @click.group()
@@ -129,6 +129,10 @@ def run_analysis(paths: Iterable[str], date: ClickDate):
             except BigQueryPermissionsError as e:
                 # TODO GLE Need to notify of error
                 logger.error(e)
+            except SqlNotDefined as e:
+                # TODO GLE Need to notify of error
+                logger.error(e)
+
     logger.info("Analysis completed")
 
 

--- a/analysis/data/metric.py
+++ b/analysis/data/metric.py
@@ -1,10 +1,13 @@
 import os
 from pathlib import Path
+from typing import Any, Dict
 
 import pandas as pd
 from google.cloud import bigquery
 from google.api_core.exceptions import Forbidden
 from pandas import DataFrame
+
+from jinja2 import Environment, FileSystemLoader, TemplateNotFound
 
 from analysis.logging import logger
 from analysis.configuration.processing_dates import ProcessingDateRange
@@ -17,59 +20,32 @@ TEMPLATE_FOLDER = PATH / "templates"
 class MetricLookupManager:
     SUBMISSION_DATE_FORMAT = "%Y-%m-%d"
 
+    def _render_sql(self, template_file: str, render_kwargs: Dict[str, Any]):
+        """Render and return the SQL from a template."""
+        file_loader = FileSystemLoader(TEMPLATE_FOLDER)
+        env = Environment(loader=file_loader)
+        try:
+            template = env.get_template(template_file)
+        except TemplateNotFound:
+            raise SqlNotDefined(filename=template_file)
+
+        sql = template.render(**render_kwargs)
+        return sql
+
     def run_query(
         self,
         query: str,
         metric: str,
-        app_name: str,
         date_range: ProcessingDateRange,
-        dimension: str = None,
-        full_dim_spec: str = None,
-        full_dim_value_spec: str = None,
     ) -> DataFrame:
-        job_config = bigquery.QueryJobConfig(
-            query_parameters=[
-                bigquery.ScalarQueryParameter(
-                    "start_date",
-                    "STRING",
-                    date_range.start_date.strftime(self.SUBMISSION_DATE_FORMAT),
-                ),
-                bigquery.ScalarQueryParameter(
-                    "end_date",
-                    "STRING",
-                    date_range.end_date.strftime(self.SUBMISSION_DATE_FORMAT),
-                ),
-            ]
-        )
-
-        query = query.replace(
-            "@window_end_date", date_range.end_date.strftime(self.SUBMISSION_DATE_FORMAT)
-        )
-
-        if dimension:
-            query = query.replace("@dimension", dimension)
-
-        if full_dim_spec and full_dim_value_spec:
-            query = query.replace("@full_dim_value_spec", full_dim_value_spec)
-            query = query.replace("@full_dim_spec", full_dim_spec)
-
-        query = query.replace("@metric", metric)
-
-        if app_name:
-            query = query.replace("@app_name", app_name)
-
         bq_client = bigquery.Client()
         # TODO GLE wait for complete
-        query_job = bq_client.query(query, job_config=job_config)
-
-        # The submission_date is dbdate, convert to datetime
+        query_job = bq_client.query(query)
         try:
             df = query_job.to_dataframe()
         except Forbidden as e:
-            raise BigQueryPermissionsError(
-                metric=metric, query=query, date_range=date_range, msg=e.message
-            )
-        # run_version_1_poc includes the submission date column, run_version_2_poc does not.
+            raise BigQueryPermissionsError(metric=metric, query=query, msg=e.message)
+
         if "submission_date" in df.columns:
             df["submission_date"] = pd.to_datetime(df["submission_date"])
         df = df.rename(columns={"dimension_value": "dimension_value_0"})
@@ -85,16 +61,19 @@ class MetricLookupManager:
         app_name: str,
         date_range: ProcessingDateRange,
     ) -> DataFrame:
-        file = TEMPLATE_FOLDER / (table_name + "_no_dim.sql")
-        if not file.is_file():
-            raise SqlNotDefined(metric=metric_name, table_name=table_name, filename=file)
+        file = table_name + "_no_dim.sql"
 
-        with open(file) as f:
-            query = f.read()
+        render_kwargs = {
+            "metric": metric_name,
+            "start_date": date_range.start_date.strftime(self.SUBMISSION_DATE_FORMAT),
+            "end_date": date_range.end_date.strftime(self.SUBMISSION_DATE_FORMAT),
+            "app_name": app_name,
+        }
+        query = self._render_sql(template_file=file, render_kwargs=render_kwargs)
+
         return self.run_query(
             query=query,
             metric=metric_name,
-            app_name=app_name,
             date_range=date_range,
         )
 
@@ -106,13 +85,8 @@ class MetricLookupManager:
         date_range: ProcessingDateRange,
         dimensions: list,  # indicates the permutation of the dimensions to evaluate.
     ) -> DataFrame:
-        file = TEMPLATE_FOLDER / (table_name + "_by_dims.sql")
-        if not file.is_file():
-            raise SqlNotDefined(metric=metric_name, table_name=table_name, filename=file)
-        with open(file) as f:
-            query = f.read()
+        file = table_name + "_by_dims.sql"
 
-        result_df = DataFrame()
         dim_value_spec = "@dimension as dimension_value"
         dim_spec = "@dimension"
         full_dim_value_spec = ""
@@ -127,22 +101,30 @@ class MetricLookupManager:
             full_dim_spec += dim_spec.replace("@dimension", dim, 1)
 
         logger.info(f"processing dimensions: {full_dim_spec}")
+
+        render_kwargs = {
+            "metric": metric_name,
+            "start_date": date_range.start_date.strftime(self.SUBMISSION_DATE_FORMAT),
+            "end_date": date_range.end_date.strftime(self.SUBMISSION_DATE_FORMAT),
+            "app_name": app_name,
+            "full_dim_value_spec": full_dim_value_spec,
+            "full_dim_spec": full_dim_spec,
+        }
+        query = self._render_sql(template_file=file, render_kwargs=render_kwargs)
+
         df = self.run_query(
             query=query,
             metric=metric_name,
-            app_name=app_name,
             date_range=date_range,
-            dimension=None,
-            full_dim_spec=full_dim_spec,
-            full_dim_value_spec=full_dim_value_spec,
         )
         # Need to add indexing to the column indicating the dimension.
         i = 0
+        result_df = DataFrame()
+
         for dim in dimensions:
             df["dimension_" + str(i)] = dim
             i += 1
 
         result_df = pd.concat([result_df, df])
-
         result_df = result_df.dropna(axis="rows")
         return result_df

--- a/analysis/data/templates/active_user_aggregates_by_dims.sql
+++ b/analysis/data/templates/active_user_aggregates_by_dims.sql
@@ -1,32 +1,32 @@
 -- Note that for this query the returned column name must be metric_value for downstream processing
 SELECT
-    @full_dim_value_spec,
+    {{ full_dim_value_spec}},
     window_average AS metric_value
 FROM (
     SELECT
         *,
         AVG(metric_value) OVER (
-        PARTITION BY @full_dim_spec ORDER BY submission_date
+        PARTITION BY {{ full_dim_spec }} ORDER BY submission_date
         ROWS BETWEEN 6 PRECEDING AND CURRENT ROW) AS window_average
     FROM (
         SELECT
             submission_date,
-            @full_dim_spec,
-            SUM(@metric) AS metric_value
+            {{ full_dim_spec }},
+            SUM({{metric}}) AS metric_value
         FROM
             `moz-fx-data-shared-prod.telemetry.active_users_aggregates` a,
             `mozdata.static.country_codes_v1` c
         WHERE
-            submission_date >= @start_date
-            AND submission_date < @end_date
-            AND app_name="@app_name"
+            submission_date >= '{{ start_date }}'
+            AND submission_date < '{{ end_date }}'
+            AND app_name = "{{app_name}}"
             AND a.country = c.code
         GROUP BY
             submission_date,
-            @full_dim_spec
+            {{full_dim_spec}}
     ) AS t1
     ORDER BY
-        @full_dim_spec,
+        {{full_dim_spec}},
         submission_date
 )
-where  submission_date = DATE_SUB(DATE "@window_end_date", INTERVAL 1 DAY)
+where  submission_date = DATE_SUB(DATE "{{end_date}}", INTERVAL 1 DAY)

--- a/analysis/data/templates/active_user_aggregates_by_dims.sql
+++ b/analysis/data/templates/active_user_aggregates_by_dims.sql
@@ -1,0 +1,32 @@
+-- Note that for this query the returned column name must be metric_value for downstream processing
+SELECT
+    @full_dim_value_spec,
+    window_average AS metric_value
+FROM (
+    SELECT
+        *,
+        AVG(metric_value) OVER (
+        PARTITION BY @full_dim_spec ORDER BY submission_date
+        ROWS BETWEEN 6 PRECEDING AND CURRENT ROW) AS window_average
+    FROM (
+        SELECT
+            submission_date,
+            @full_dim_spec,
+            SUM(@metric) AS metric_value
+        FROM
+            `moz-fx-data-shared-prod.telemetry.active_users_aggregates` a,
+            `mozdata.static.country_codes_v1` c
+        WHERE
+            submission_date >= @start_date
+            AND submission_date < @end_date
+            AND app_name="@app_name"
+            AND a.country = c.code
+        GROUP BY
+            submission_date,
+            @full_dim_spec
+    ) AS t1
+    ORDER BY
+        @full_dim_spec,
+        submission_date
+)
+where  submission_date = DATE_SUB(DATE "@window_end_date", INTERVAL 1 DAY)

--- a/analysis/data/templates/active_user_aggregates_no_dim.sql
+++ b/analysis/data/templates/active_user_aggregates_no_dim.sql
@@ -8,13 +8,13 @@ SELECT window_average AS metric_value from (
         SELECT
             submission_date,
             app_name,
-            SUM(@metric) AS metric_value
+            SUM({{ metric }}) AS metric_value
         FROM
             `moz-fx-data-shared-prod.telemetry.active_users_aggregates` a
         WHERE
-            submission_date >= @start_date
-            AND submission_date < @end_date
-            AND app_name="@app_name"
+            submission_date >= '{{ start_date }}'
+            AND submission_date < '{{ end_date }}'
+            AND app_name="{{ app_name }}"
         GROUP BY
             submission_date,
             app_name
@@ -22,4 +22,4 @@ SELECT window_average AS metric_value from (
     ORDER BY
     submission_date
 )
-where  submission_date = DATE_SUB(DATE "@window_end_date", INTERVAL 1 DAY)
+where  submission_date = DATE_SUB(DATE "{{end_date}}", INTERVAL 1 DAY)

--- a/analysis/data/templates/active_user_aggregates_no_dim.sql
+++ b/analysis/data/templates/active_user_aggregates_no_dim.sql
@@ -1,0 +1,25 @@
+-- Note that for this query the returned column name must be metric_value for downstream processing
+SELECT window_average AS metric_value from (
+    SELECT
+        *,
+        AVG(metric_value) OVER (ORDER BY submission_date
+        ROWS BETWEEN 6 PRECEDING AND CURRENT ROW) AS window_average
+    FROM (
+        SELECT
+            submission_date,
+            app_name,
+            SUM(@metric) AS metric_value
+        FROM
+            `moz-fx-data-shared-prod.telemetry.active_users_aggregates` a
+        WHERE
+            submission_date >= @start_date
+            AND submission_date < @end_date
+            AND app_name="@app_name"
+        GROUP BY
+            submission_date,
+            app_name
+    ) AS t1
+    ORDER BY
+    submission_date
+)
+where  submission_date = DATE_SUB(DATE "@window_end_date", INTERVAL 1 DAY)

--- a/analysis/data/templates/www_site_metrics_summary_v1_by_dims.sql
+++ b/analysis/data/templates/www_site_metrics_summary_v1_by_dims.sql
@@ -1,30 +1,30 @@
 -- Note that for this query the returned column name must be metric_value for downstream processing
 SELECT
-    @full_dim_value_spec,
+    {{ full_dim_value_spec }},
     window_average AS metric_value
 FROM (
     SELECT
         *,
         AVG(metric_value) OVER (
-        PARTITION BY @full_dim_spec ORDER BY submission_date
+        PARTITION BY {{ full_dim_spec }} ORDER BY submission_date
         ROWS BETWEEN 6 PRECEDING AND CURRENT ROW) AS window_average
     FROM (
         SELECT
             date as submission_date,
-            @full_dim_spec,
-            SUM(@metric) AS metric_value
+            {{ full_dim_spec }},
+            SUM({{ metric }}) AS metric_value
         FROM
             `moz-fx-data-marketing-prod.ga_derived.www_site_metrics_summary_v1`
         WHERE
-            date >= @start_date
-            AND date < @end_date
+            date >= '{{ start_date }}'
+            AND date < '{{ end_date }}'
         GROUP BY
             date,
-            @full_dim_spec
+            {{ full_dim_spec }}
 
     ) AS t1
     ORDER BY
-        @full_dim_spec,
+        {{ full_dim_spec }},
         submission_date
 )
-where  submission_date = DATE_SUB(DATE "@window_end_date", INTERVAL 1 DAY)
+where  submission_date = DATE_SUB(DATE "{{end_date}}", INTERVAL 1 DAY)

--- a/analysis/data/templates/www_site_metrics_summary_v1_by_dims.sql
+++ b/analysis/data/templates/www_site_metrics_summary_v1_by_dims.sql
@@ -1,0 +1,30 @@
+-- Note that for this query the returned column name must be metric_value for downstream processing
+SELECT
+    @full_dim_value_spec,
+    window_average AS metric_value
+FROM (
+    SELECT
+        *,
+        AVG(metric_value) OVER (
+        PARTITION BY @full_dim_spec ORDER BY submission_date
+        ROWS BETWEEN 6 PRECEDING AND CURRENT ROW) AS window_average
+    FROM (
+        SELECT
+            date as submission_date,
+            @full_dim_spec,
+            SUM(@metric) AS metric_value
+        FROM
+            `moz-fx-data-marketing-prod.ga_derived.www_site_metrics_summary_v1`
+        WHERE
+            date >= @start_date
+            AND date < @end_date
+        GROUP BY
+            date,
+            @full_dim_spec
+
+    ) AS t1
+    ORDER BY
+        @full_dim_spec,
+        submission_date
+)
+where  submission_date = DATE_SUB(DATE "@window_end_date", INTERVAL 1 DAY)

--- a/analysis/data/templates/www_site_metrics_summary_v1_no_dim.sql
+++ b/analysis/data/templates/www_site_metrics_summary_v1_no_dim.sql
@@ -1,0 +1,22 @@
+-- Note that for this query the returned column name must be metric_value for downstream processing
+SELECT window_average AS metric_value from (
+    SELECT
+        *,
+        AVG(metric_value) OVER (ORDER BY submission_date
+        ROWS BETWEEN 6 PRECEDING AND CURRENT ROW) AS window_average
+    FROM (
+        SELECT
+            date as submission_date,
+            sum(@metric) AS metric_value
+        FROM
+            `moz-fx-data-marketing-prod.ga_derived.www_site_metrics_summary_v1`
+        WHERE
+            date >= @start_date
+            AND date < @end_date
+        GROUP BY date
+        ORDER BY date desc
+    ) AS t1
+    ORDER BY
+    submission_date
+)
+where  submission_date = DATE_SUB(DATE "@window_end_date", INTERVAL 1 DAY)

--- a/analysis/data/templates/www_site_metrics_summary_v1_no_dim.sql
+++ b/analysis/data/templates/www_site_metrics_summary_v1_no_dim.sql
@@ -7,16 +7,16 @@ SELECT window_average AS metric_value from (
     FROM (
         SELECT
             date as submission_date,
-            sum(@metric) AS metric_value
+            sum({{ metric }}) AS metric_value
         FROM
             `moz-fx-data-marketing-prod.ga_derived.www_site_metrics_summary_v1`
         WHERE
-            date >= @start_date
-            AND date < @end_date
+            date >= '{{ start_date }}'
+            AND date < '{{ end_date }}'
         GROUP BY date
         ORDER BY date desc
     ) AS t1
     ORDER BY
     submission_date
 )
-where  submission_date = DATE_SUB(DATE "@window_end_date", INTERVAL 1 DAY)
+where  submission_date = DATE_SUB(DATE "{{end_date}}", INTERVAL 1 DAY)

--- a/analysis/detection/explorer/dimension_evaluator.py
+++ b/analysis/detection/explorer/dimension_evaluator.py
@@ -10,10 +10,6 @@ from analysis.logging import logger
 
 class DimensionEvaluator(ABC):
     @abstractmethod
-    def _get_current_and_baseline_values(self, dimensions: list):
-        pass
-
-    @abstractmethod
     def evaluate(self) -> dict:
         pass
 

--- a/analysis/detection/explorer/multiple_dimensions.py
+++ b/analysis/detection/explorer/multiple_dimensions.py
@@ -35,23 +35,20 @@ class MultiDimensionEvaluator(DimensionEvaluator):
             'dimension' column contains one value, the name of the dimension (e.g. 'country').
             'timeframe' column values are either "current" or "baseline".
         """
-        if len(dimensions) != 1:
-            raise ValueError("Can only specify 1 set of dimensions")
-
-        current = MetricLookupManager().get_metric_by_multi_dimensions_with_date_range(
+        current = MetricLookupManager().get_metric_by_dimensions_with_date_range(
             metric_name=self.profile.dataset.metric_name,
             table_name=self.profile.dataset.table_name,
             app_name=self.profile.dataset.app_name,
             date_range=self.current_period,
-            dimensions=dimensions[0],
+            dimensions=dimensions,
         )
         current["timeframe"] = "current"
-        baseline = MetricLookupManager().get_metric_by_multi_dimensions_with_date_range(
+        baseline = MetricLookupManager().get_metric_by_dimensions_with_date_range(
             metric_name=self.profile.dataset.metric_name,
             table_name=self.profile.dataset.table_name,
             app_name=self.profile.dataset.app_name,
             date_range=self.baseline_period,
-            dimensions=dimensions[0],
+            dimensions=dimensions,
         )
         baseline["timeframe"] = "baseline"
 
@@ -88,7 +85,7 @@ class MultiDimensionEvaluator(DimensionEvaluator):
         dim_permutations = list(set(tuple(sorted(perm)) for perm in dim_permutations))
 
         for pair in dim_permutations:
-            values = self._get_current_and_baseline_values(dimensions=[pair])
+            values = self._get_current_and_baseline_values(dimensions=list(pair))
             percent_change_df = self._calculate_percent_change(df=values)
             contrib_to_overall_change_df = self._calculate_contribution_to_overall_change(
                 parent_df=top_level_df, current_df=values

--- a/analysis/detection/explorer/one_dimension.py
+++ b/analysis/detection/explorer/one_dimension.py
@@ -22,7 +22,7 @@ class OneDimensionEvaluator(DimensionEvaluator):
         self.baseline_period = baseline_period
         self.current_period = current_period
 
-    def _get_current_and_baseline_values(self, dimensions: list) -> DataFrame:
+    def _get_current_and_baseline_values(self, dimension: str) -> DataFrame:
         """
         Retrieves the current and baseline values for the metric specified in the AnalysisProfile.
         Although all dimensions are included in the AnalysisProfile, only the dimension specified as
@@ -34,24 +34,22 @@ class OneDimensionEvaluator(DimensionEvaluator):
             'dimension' column contains one value, the name of the dimension (e.g. 'country').
             'timeframe' column values are either "current" or "baseline".
         """
-        if len(dimensions) != 1:
-            raise ValueError("Can only specify 1 dimension")
 
         # For the one dimension evaluator if we are given a list we process each one separately.
-        current_by_dimension = MetricLookupManager().get_metric_by_dimension_with_date_range(
+        current_by_dimension = MetricLookupManager().get_metric_by_dimensions_with_date_range(
             metric_name=self.profile.dataset.metric_name,
             table_name=self.profile.dataset.table_name,
             app_name=self.profile.dataset.app_name,
             date_range=self.current_period,
-            dimension=dimensions[0],
+            dimensions=[dimension],
         )
         current_by_dimension["timeframe"] = "current"
-        baseline_by_dimension = MetricLookupManager().get_metric_by_dimension_with_date_range(
+        baseline_by_dimension = MetricLookupManager().get_metric_by_dimensions_with_date_range(
             metric_name=self.profile.dataset.metric_name,
             table_name=self.profile.dataset.table_name,
             app_name=self.profile.dataset.app_name,
             date_range=self.baseline_period,
-            dimension=dimensions[0],
+            dimensions=[dimension],
         )
         baseline_by_dimension["timeframe"] = "baseline"
 
@@ -83,7 +81,7 @@ class OneDimensionEvaluator(DimensionEvaluator):
         )._get_current_and_baseline_values()
 
         for dimension in self.profile.percent_change.dimensions:
-            values = self._get_current_and_baseline_values(dimensions=[dimension])
+            values = self._get_current_and_baseline_values(dimension=dimension)
             percent_change_df = self._calculate_percent_change(df=values)
             contrib_to_overall_change_df = self._calculate_contribution_to_overall_change(
                 parent_df=top_level_df, current_df=values

--- a/analysis/errors.py
+++ b/analysis/errors.py
@@ -14,3 +14,8 @@ class BigQueryPermissionsError(Exception):
             f"Unable to access data for metric: {metric} date_range: {date_range} {msg }query: "
             f"\n{query} "
         )
+
+
+class SqlNotDefined(Exception):
+    def __init__(self, metric: str, table_name: str, filename: str):
+        super().__init__(f"Sql not defined for table_name: {table_name}, expected file: {filename}")

--- a/analysis/errors.py
+++ b/analysis/errors.py
@@ -9,13 +9,10 @@ class NoDataFoundForDateRange(Exception):
 
 
 class BigQueryPermissionsError(Exception):
-    def __init__(self, metric: str, query: str, date_range: ProcessingDateRange, msg: str):
-        super().__init__(
-            f"Unable to access data for metric: {metric} date_range: {date_range} {msg }query: "
-            f"\n{query} "
-        )
+    def __init__(self, metric: str, query: str, msg: str):
+        super().__init__(f"Unable to access data for metric: {metric} {msg } query: " f"\n{query} ")
 
 
 class SqlNotDefined(Exception):
-    def __init__(self, metric: str, table_name: str, filename: str):
-        super().__init__(f"Sql not defined for table_name: {table_name}, expected file: {filename}")
+    def __init__(self, filename: str):
+        super().__init__(f"Sql missing, expected file: {filename}")


### PR DESCRIPTION
- Extracted the SQL queries which were contained in the `metrics.py` file into SQL files in `analysis/data/templates`.
- The SQL query is constructed using Jinja templating.
- There are two files per `table_name`, one which does not use any dimensions (`*_no_dims.sql`), and a second file for querying with one or more dimensions (`*_by_dims.sql`).
- Which pair of query files selected is determined by `table_name` from the analysis configuration (`config_files`).
- Since the selection of which template is use is based on the `table_name` from the analysis configuration and appends `_no_dims.sql` or `_by_dims.sql` to determine the filename, it is possible that there could be an error in loading the file if there is a mistake in the filename.  If the expected file is not found then a `SqlNotDefined` error is raised
 