### PR TITLE
DENG-473 and DENG-474, removed multiple queries to get top level data

### DIFF
--- a/analysis/cli.py
+++ b/analysis/cli.py
@@ -44,6 +44,7 @@ def find_significant_dimensions(
         profile=profile,
         baseline_period=baseline_period,
         current_period=current_period,
+        parent_df=top_level_evaluation.get("top_level_values"),
     )
     one_dim_evaluation = one_dim_evaluator.evaluate()
 
@@ -51,6 +52,7 @@ def find_significant_dimensions(
         profile=profile,
         baseline_period=baseline_period,
         current_period=current_period,
+        parent_df=top_level_evaluation.get("top_level_values"),
     )
     multi_dim_evaluation = multi_dim_evaluator.evaluate()
 

--- a/analysis/detection/explorer/one_dimension.py
+++ b/analysis/detection/explorer/one_dimension.py
@@ -5,7 +5,6 @@ from pandas import DataFrame
 
 from analysis.data.metric import MetricLookupManager
 from analysis.detection.explorer.dimension_evaluator import DimensionEvaluator
-from analysis.detection.explorer.top_level import TopLevelEvaluator
 from analysis.configuration.configs import AnalysisProfile
 from analysis.configuration.processing_dates import ProcessingDateRange
 
@@ -16,7 +15,9 @@ class OneDimensionEvaluator(DimensionEvaluator):
         profile: AnalysisProfile,
         baseline_period: ProcessingDateRange,
         current_period: ProcessingDateRange,
+        parent_df: DataFrame,
     ):
+        super().__init__(parent_df)
         # Currently the profile only references percent_change.
         self.profile = profile
         self.baseline_period = baseline_period
@@ -73,22 +74,13 @@ class OneDimensionEvaluator(DimensionEvaluator):
         )
         large_contrib_to_change = {}
 
-        # TODO GLE THIS IS VERY BAD NEED TO USE A CACHED VALUE
-        top_level_df = TopLevelEvaluator(
-            profile=self.profile,
-            baseline_period=self.baseline_period,
-            current_period=self.current_period,
-        )._get_current_and_baseline_values()
-
         for dimension in self.profile.percent_change.dimensions:
             values = self._get_current_and_baseline_values(dimension=dimension)
             percent_change_df = self._calculate_percent_change(df=values)
             contrib_to_overall_change_df = self._calculate_contribution_to_overall_change(
-                parent_df=top_level_df, current_df=values
+                current_df=values
             )
-            change_in_proportion_df = self._calculate_change_in_proportion(
-                parent_df=top_level_df, current_df=values
-            )
+            change_in_proportion_df = self._calculate_change_in_proportion(current_df=values)
             change_distance_df = self._calculate_change_distance(
                 contrib_to_overall_change_df=contrib_to_overall_change_df,
                 change_in_proportion_df=change_in_proportion_df,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,7 +108,7 @@ def mock_baseline_multi_dimension_values():
 
 
 @pytest.fixture
-def parent_df(mock_current_parent_values, mock_baseline_parent_values):
+def mock_parent_df(mock_current_parent_values, mock_baseline_parent_values):
     return concat([mock_current_parent_values, mock_baseline_parent_values])
 
 

--- a/tests/test_all_dimensions.py
+++ b/tests/test_all_dimensions.py
@@ -10,7 +10,7 @@ def test_change_distance_one_dim(
     mock_baseline_period,
     mock_current_period,
     dimension_df,
-    parent_df,
+    mock_parent_df,
     mock_analysis_profile,
 ):
     # calculation =
@@ -29,20 +29,22 @@ def test_change_distance_one_dim(
         profile=mock_analysis_profile,
         baseline_period=mock_baseline_period,
         current_period=mock_current_period,
+        parent_df=mock_parent_df,
     )
 
     contr_to_change = one_dim_evaluation._calculate_contribution_to_overall_change(
-        current_df=dimension_df, parent_df=parent_df
+        current_df=dimension_df
     )
 
     change_in_proportion = one_dim_evaluation._calculate_change_in_proportion(
-        current_df=dimension_df, parent_df=parent_df
+        current_df=dimension_df
     )
 
     multi_dim_evaluation = MultiDimensionEvaluator(
         profile=mock_analysis_profile,
         baseline_period=mock_baseline_period,
         current_period=mock_current_period,
+        parent_df=mock_parent_df,
     )
 
     change_distance_df = AllDimensionEvaluator(
@@ -59,7 +61,7 @@ def test_change_distance_multi_dim(
     mock_baseline_period,
     mock_current_period,
     multi_dimension_df,
-    parent_df,
+    mock_parent_df,
     mock_analysis_profile,
 ):
     # calculation =
@@ -89,21 +91,22 @@ def test_change_distance_multi_dim(
         profile=mock_analysis_profile,
         baseline_period=mock_baseline_period,
         current_period=mock_current_period,
+        parent_df=mock_parent_df,
     )
 
     multi_dim_evaluation = MultiDimensionEvaluator(
         profile=mock_analysis_profile,
         baseline_period=mock_baseline_period,
         current_period=mock_current_period,
+        parent_df=mock_parent_df,
     )
 
     contr_to_change = multi_dim_evaluation._calculate_contribution_to_overall_change(
-        current_df=multi_dimension_df,
-        parent_df=parent_df,
+        current_df=multi_dimension_df
     )
 
     change_in_proportion = multi_dim_evaluation._calculate_change_in_proportion(
-        current_df=multi_dimension_df, parent_df=parent_df
+        current_df=multi_dimension_df
     )
 
     change_distance_df = AllDimensionEvaluator(

--- a/tests/test_multiple_dimensions.py
+++ b/tests/test_multiple_dimensions.py
@@ -5,7 +5,11 @@ from analysis.detection.explorer.multiple_dimensions import MultiDimensionEvalua
 
 
 def test_percent_change(
-    mock_baseline_period, mock_current_period, multi_dimension_df, mock_analysis_profile
+    mock_parent_df,
+    mock_baseline_period,
+    mock_current_period,
+    multi_dimension_df,
+    mock_analysis_profile,
 ):
     rows = [
         ["mx", "nightly", 100.0, "country", "channel"],
@@ -31,6 +35,7 @@ def test_percent_change(
         profile=mock_analysis_profile,
         baseline_period=mock_baseline_period,
         current_period=mock_current_period,
+        parent_df=mock_parent_df,
     )._calculate_percent_change(df=multi_dimension_df)
     assert_frame_equal(expected_df, percent_change)
 
@@ -39,7 +44,7 @@ def test_calculate_contribution_to_overall_change(
     mock_baseline_period,
     mock_current_period,
     multi_dimension_df,
-    parent_df,
+    mock_parent_df,
     mock_analysis_profile,
 ):
     # calculation =
@@ -68,7 +73,8 @@ def test_calculate_contribution_to_overall_change(
         profile=mock_analysis_profile,
         baseline_period=mock_baseline_period,
         current_period=mock_current_period,
-    )._calculate_contribution_to_overall_change(current_df=multi_dimension_df, parent_df=parent_df)
+        parent_df=mock_parent_df,
+    )._calculate_contribution_to_overall_change(current_df=multi_dimension_df)
 
     assert_frame_equal(expected_df, contr_to_change)
 
@@ -77,7 +83,7 @@ def test_change_in_proportion(
     mock_baseline_period,
     mock_current_period,
     multi_dimension_df,
-    parent_df,
+    mock_parent_df,
     mock_analysis_profile,
 ):
     # calculation =
@@ -108,6 +114,7 @@ def test_change_in_proportion(
         profile=mock_analysis_profile,
         baseline_period=mock_baseline_period,
         current_period=mock_current_period,
-    )._calculate_change_in_proportion(current_df=multi_dimension_df, parent_df=parent_df)
+        parent_df=mock_parent_df,
+    )._calculate_change_in_proportion(current_df=multi_dimension_df)
 
     assert_frame_equal(expected_df, change_in_proportion)

--- a/tests/test_one_dimension.py
+++ b/tests/test_one_dimension.py
@@ -5,7 +5,7 @@ from analysis.detection.explorer.one_dimension import OneDimensionEvaluator
 
 
 def test_percent_change(
-    mock_baseline_period, mock_current_period, dimension_df, mock_analysis_profile
+    mock_parent_df, mock_baseline_period, mock_current_period, dimension_df, mock_analysis_profile
 ):
     rows = [
         ["mx", 26.6667, "country"],
@@ -19,6 +19,7 @@ def test_percent_change(
         profile=mock_analysis_profile,
         baseline_period=mock_baseline_period,
         current_period=mock_current_period,
+        parent_df=mock_parent_df,
     )._calculate_percent_change(df=dimension_df)
     assert_frame_equal(expected_df, percent_change)
 
@@ -27,7 +28,7 @@ def test_calculate_contribution_to_overall_change(
     mock_baseline_period,
     mock_current_period,
     dimension_df,
-    parent_df,
+    mock_parent_df,
     mock_analysis_profile,
 ):
     # calculation =
@@ -44,7 +45,8 @@ def test_calculate_contribution_to_overall_change(
         profile=mock_analysis_profile,
         baseline_period=mock_baseline_period,
         current_period=mock_current_period,
-    )._calculate_contribution_to_overall_change(current_df=dimension_df, parent_df=parent_df)
+        parent_df=mock_parent_df,
+    )._calculate_contribution_to_overall_change(current_df=dimension_df)
 
     assert_frame_equal(expected_df, contr_to_change)
 
@@ -53,7 +55,7 @@ def test_change_in_proportion(
     mock_baseline_period,
     mock_current_period,
     dimension_df,
-    parent_df,
+    mock_parent_df,
     mock_analysis_profile,
 ):
     # calculation =
@@ -72,6 +74,7 @@ def test_change_in_proportion(
         profile=mock_analysis_profile,
         baseline_period=mock_baseline_period,
         current_period=mock_current_period,
-    )._calculate_change_in_proportion(current_df=dimension_df, parent_df=parent_df)
+        parent_df=mock_parent_df,
+    )._calculate_change_in_proportion(current_df=dimension_df)
 
     assert_frame_equal(expected_df, change_in_proportion)

--- a/tests/test_top_level.py
+++ b/tests/test_top_level.py
@@ -4,7 +4,7 @@ from analysis.detection.explorer.top_level import TopLevelEvaluator
 from analysis.configuration.processing_dates import ProcessingDateRange
 
 
-def test_percent_change(parent_df, mock_analysis_profile):
+def test_percent_change(mock_parent_df, mock_analysis_profile):
     baseline_period = ProcessingDateRange(
         start_date=datetime.strptime("2022-04-02", "%Y-%m-%d"),
         end_date=datetime.strptime("2022-04-02", "%Y-%m-%d"),
@@ -19,5 +19,5 @@ def test_percent_change(parent_df, mock_analysis_profile):
         profile=mock_analysis_profile,
         baseline_period=baseline_period,
         current_period=current_period,
-    )._calculate_percent_change(df=parent_df)
+    )._calculate_percent_change(df=mock_parent_df)
     assert percent_change == expected_percent


### PR DESCRIPTION
1. Renamed `parent_df` to `mock_parent_df` in `conftest.py` for clarity.  Resulted in multiple touch points.
2. Moved the `parent_df` to `DimensionEvaluator` and removed it as a parameter to 
> - _calculate_contribution_to_overall_change
> - _calculate_change_in_proportion

3. Removed the extra query in .evaluate since the `parent_df` is now cached in the `DimensionEvaluator`